### PR TITLE
feat: Affinement de la logique de simplification des tableaux

### DIFF
--- a/knowledge/falc_guidelines.md
+++ b/knowledge/falc_guidelines.md
@@ -13,14 +13,18 @@ Expliquer chaque information de façon claire et simple pour que toute personne 
 - Phrases courtes.
 - Voix active.
 - Temps présent quand c’est possible.
-- Formulations positives (mettre **pas** en gras si nécessaire).
+- **Formulations positives.**
+  - **Tournure à éviter :** "Qui peut vous aider si vous avez des questions ?"
+  - **Tournure à privilégier :** "Vous avez des questions ?"
+  - Si une négation est indispensable, mettre le mot **pas** en gras.
+- **Ne pas commencer une phrase par "Ou", "Alors", "Donc" ou "Si".**
+  - **Exception :** La structure "Question ? Alors..." est autorisée pour poser une condition.
 - Pas de phrases hypothétiques.
-- ***Si une phrase commence par « si », poser la condition sous forme de question puis répondre avec « Alors… ».***
 
 ### 2.2 Mots
 - Mots simples, connus, adaptés au lecteur.
-- Même mot pour la même chose (isosemie).
-- Pas de jargon ni mots étrangers.
+- **Toujours utiliser le même mot pour la même chose (isosemie).** Par exemple, si vous choisissez le mot "logement", utilisez-le dans tout le document et ne le remplacez pas par "bail" ou "appartement".
+- **Pas de jargon ni de mots étrangers.** Éviter les termes juridiques complexes comme "résiliation" ou "anticipée". Si un mot complexe est indispensable, il faut l'expliquer simplement.
 - Pas d’abréviations.
 - Expliquer un mot difficile au moment où il apparaît.
 - Donner des exemples concrets.
@@ -51,8 +55,9 @@ Expliquer chaque information de façon claire et simple pour que toute personne 
 ## 3. Organisation du contenu
 - Regrouper chaque sujet dans une section unique.
 - Titres et sous‑titres sous forme de questions (« Quand ? », « Où ? », « Pourquoi ? », « Que faire ? »).
-- Expliquer l’objectif du document au début.
+- **Expliquer l’objectif du document au début.** Ne pas répéter l'objet du courrier dans la première phrase.
 - Placer les informations les plus importantes en premier, en gras ou dans un encadré.
+- **Ne jamais ajouter de récapitulatif ou de résumé à la fin du document.** Le document doit être concis.
 - Glossaire en fin de long document.
 
 ## 4. Tableaux et icônes

--- a/src/falc_crew/config/tasks.yaml
+++ b/src/falc_crew/config/tasks.yaml
@@ -11,7 +11,13 @@ translate_text_task:
 
     **VERY IMPORTANT: You MUST consult and meticulously apply ALL rules from the 'Règles d'édition FALC' document (available in your knowledge base) for every sentence you write.**
     This includes specific instructions for sentence structure, vocabulary, numbers, dates, lists, complex structures (conditions, cause/effect, etc.), and forbidden phrases.
-    Pay special attention to the rule: "Si une phrase commence par 'si', poser la condition sous forme de question puis répondre avec 'Alors...'."
+
+    **KEY STYLE AND CONTENT RULES TO FOLLOW:**
+    - **No Summaries:** Absolutely do not add a summary or recap at the end of the document. The translation must end after the last piece of information.
+    - **Consistent Vocabulary (Isosemie):** Be extremely consistent with your choice of words. If you translate a term one way (e.g., "logement"), you must use that same word throughout the entire document. Do not use synonyms like "bail" or "appartement".
+    - **Sentence Starters:** Do not start sentences with "Ou", "Alors", or "Donc". The only exception is the "Question? Alors..." pattern for conditions.
+    - **No Subject Repetition:** Do not repeat the letter's subject in the first sentence. The first sentence should state the document's purpose directly.
+    - **Positive Phrasing:** Always prefer positive sentences. For example, instead of "Qui peut vous aider si vous avez des questions ?", write "Vous avez des questions ?".
 
     **All output sentences must be grammatically correct French, even when simplified.**
 
@@ -128,6 +134,50 @@ table_optimizer_task:
   description: >
     Review the FALC translator's `body_sections` and identify opportunities to restructure content into tables for improved clarity and readability, then define the table data.
     **VERY IMPORTANT: The final `body_sections` list you output MUST contain ALL original content that was NOT converted into a table, PLUS the `[[TABLE:key]]` placeholders for any tables you created. All items must be in their correct original relative order.**
+
+    **NEW CRITICAL RULE: SIMPLIFYING TABLES WITH QUESTION TITLES**
+    A common pattern is a question followed by a list of answers. When you identify this, you must simplify the table structure to its core information.
+
+    If a block of content you are converting to a table is immediately preceded by a paragraph that is a question (e.g., "Qui paie les frais pour les lunettes ?"), you MUST follow this procedure:
+    1.  **Use the question as the `title` for the table.**
+    2.  **Remove the question paragraph** from the `body_sections` along with the content being converted to a table.
+    3.  **Always hide the column headers** for this type of table by setting `hide_column_headers: true`. The title is sufficient.
+    4.  **Analyze and simplify the columns:**
+        a.  Examine the first column of your potential table. If its content is a simple, direct repetition of the question's theme (e.g., the title is "Qui paie les frais ?" and the first column only contains "Qui ?"), then this first column is redundant and **MUST BE ENTIRELY REMOVED** from the `rows` data.
+        b.  The result might be a table with only a single column, which is the desired outcome.
+        c.  However, if the first column contains essential non-redundant information (like step numbers: "1", "2", "3"), it should be kept.
+
+    **Example of desired transformation:**
+
+    *Initial Text from Translator:*
+    ```
+    "Qui paie les frais pour les lunettes ?",
+    "Qui ?:",
+    "Notre établissement paie les lunettes...",
+    ```
+
+    *Your Correct Output:*
+    - `title`: "Qui paie les frais pour les lunettes ?"
+    - `hide_column_headers`: true
+    - `columns`: ["", ""]
+    - `rows`: [["Notre établissement paie les lunettes..."]]
+
+    **Another Example:**
+
+    *Initial Text from Translator:*
+    ```
+    "Que devez-vous faire ?",
+    "Étape 1:",
+    "Vous devez aller...",
+    "Étape 2:",
+    "Vous devez prendre...",
+    ```
+
+    *Your Correct Output:*
+    - `title`: "Que devez-vous faire ?"
+    - `hide_column_headers`: true
+    - `columns`: ["Étape", "Action"]
+    - `rows`: [["1", "Vous devez aller..."], ["2", "Vous devez prendre..."]]
 
      **1. Identify Content Suitable for Tables:**
       Actively look for various types of information that would benefit from a tabular presentation, such as:


### PR DESCRIPTION
Cette modification affine les instructions de l'agent `table_optimizer` pour améliorer la clarté des tableaux générés, en se basant sur les retours utilisateurs.

La nouvelle logique est la suivante :
1.  Lorsqu'une question précède un tableau, elle est utilisée comme titre (`title`) du tableau.
2.  Les en-têtes de colonnes (`column_headers`) sont systématiquement masqués dans ce cas.
3.  Si la première colonne du tableau est une simple répétition de la question (par exemple, la colonne "Qui ?" pour la question "Qui paie ?"), elle est entièrement supprimée des données du tableau.

Cela permet de créer des tableaux beaucoup plus concis et d'éliminer toute redondance entre le texte et le tableau, comme demandé.

Les changements sont appliqués dans `src/falc_crew/config/tasks.yaml`.